### PR TITLE
Add web-based Phraser Beam game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# Phraser_Beam
+# Phraser Beam
+
+A small browser game inspired by Wheel of Fortune. Guess the hidden phrase while conserving blasts from your **Phraser Beam** blaster. Common letters cost more blasts!
+
+## Running
+
+Open `index.html` in any modern web browser. If the keyboard does not load phrases correctly, you may need to serve the files via a local web server due to browser security restrictions. For example:
+
+```bash
+python3 -m http.server
+```
+
+Then visit `http://localhost:8000`.
+
+## Gameplay
+
+1. A random phrase from `phrases.csv` is chosen.
+2. Click letters on the on‑screen keyboard to guess them.
+3. Each guess consumes blasts according to an inverse Scrabble score – rarer letters cost fewer blasts.
+4. When all letters are revealed, a victory screen shows how many blasts you used.
+
+Enjoy the whimsical aliens cheering you on!

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Phraser Beam</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="script.js" defer></script>
+</head>
+<body>
+  <div id="game">
+    <h1>Phraser Beam</h1>
+    <div id="aliens">
+      <div class="alien" id="alien-left"></div>
+      <div class="alien" id="alien-right"></div>
+    </div>
+    <div id="beam" class="hidden"></div>
+    <div id="phrase"></div>
+    <div id="keyboard"></div>
+    <div id="status">Blasts used: <span id="blasts">0</span></div>
+  </div>
+  <div id="victory" class="hidden">
+    <div class="alien victory"></div>
+    <p id="final-message"></p>
+    <button id="play-again">Play Again</button>
+  </div>
+</body>
+</html>

--- a/phrases.csv
+++ b/phrases.csv
@@ -1,0 +1,11 @@
+phrase
+A piece of cake
+Break a leg
+Once in a blue moon
+When pigs fly
+Under the weather
+The ball is in your court
+Let the cat out of the bag
+Hit the nail on the head
+Kill two birds with one stone
+Bite the bullet

--- a/script.js
+++ b/script.js
@@ -1,0 +1,97 @@
+let phrases = [];
+let currentPhrase = '';
+let displayed = [];
+let blastsUsed = 0;
+let letterCosts = {
+  A:10,E:10,I:10,O:10,N:10,R:10,T:10,L:10,S:10,U:10,
+  D:9,G:9,
+  B:8,C:8,M:8,P:8,
+  F:7,H:7,V:7,W:7,Y:7,
+  K:6,
+  J:3,X:3,
+  Q:1,Z:1
+};
+
+async function loadPhrases() {
+  const res = await fetch('phrases.csv');
+  const text = await res.text();
+  const lines = text.trim().split(/\n/);
+  phrases = lines.slice(1); // skip header
+}
+
+function pickPhrase() {
+  currentPhrase = phrases[Math.floor(Math.random()*phrases.length)].toUpperCase();
+  displayed = Array.from(currentPhrase).map(ch => (ch === ' ' ? ' ' : '_'));
+}
+
+function renderPhrase() {
+  const phraseDiv = document.getElementById('phrase');
+  phraseDiv.textContent = displayed.join(' ');
+}
+
+function createKeyboard() {
+  const kb = document.getElementById('keyboard');
+  kb.innerHTML = '';
+  for (let i=65; i<=90; i++) {
+    const letter = String.fromCharCode(i);
+    const btn = document.createElement('button');
+    btn.textContent = letter;
+    btn.addEventListener('click', () => guess(letter, btn));
+    kb.appendChild(btn);
+  }
+}
+
+function updateBlasts() {
+  document.getElementById('blasts').textContent = blastsUsed;
+}
+
+function showBeam() {
+  const beam = document.getElementById('beam');
+  beam.classList.remove('hidden');
+  beam.addEventListener('animationend', () => {
+    beam.classList.add('hidden');
+  }, { once: true });
+}
+
+function guess(letter, btn) {
+  btn.disabled = true;
+  const cost = letterCosts[letter] || 10;
+  blastsUsed += cost;
+  updateBlasts();
+  showBeam();
+  let found = false;
+  for (let i=0; i<currentPhrase.length; i++) {
+    if (currentPhrase[i] === letter) {
+      displayed[i] = letter;
+      found = true;
+    }
+  }
+  renderPhrase();
+  checkEnd();
+}
+
+function checkEnd() {
+  if (displayed.join('') === currentPhrase) {
+    document.getElementById('game').classList.add('hidden');
+    document.getElementById('victory').classList.remove('hidden');
+    document.getElementById('final-message').textContent =
+      `Victory! It took ${blastsUsed} blasts.`;
+  }
+}
+
+async function startGame() {
+  blastsUsed = 0;
+  updateBlasts();
+  document.getElementById('victory').classList.add('hidden');
+  document.getElementById('game').classList.remove('hidden');
+  if (phrases.length === 0) {
+    await loadPhrases();
+  }
+  pickPhrase();
+  renderPhrase();
+  createKeyboard();
+}
+
+document.getElementById('play-again').addEventListener('click', startGame);
+
+startGame();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,82 @@
+body {
+  font-family: sans-serif;
+  background: #111;
+  color: #fff;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+}
+#game {
+  padding-top: 20px;
+}
+#phrase {
+  font-size: 2em;
+  margin: 20px 0;
+}
+#keyboard button {
+  margin: 2px;
+  width: 30px;
+  height: 40px;
+  font-size: 1em;
+}
+#status {
+  margin: 15px 0;
+}
+.alien {
+  width: 60px;
+  height: 60px;
+  background: green;
+  border-radius: 50%;
+  position: relative;
+  display: inline-block;
+}
+.alien::before,
+.alien::after {
+  content: "";
+  position: absolute;
+  width: 15px;
+  height: 20px;
+  background: green;
+  top: -20px;
+  border-radius: 50% 50% 0 0;
+}
+.alien::before { left: 5px; }
+.alien::after { right: 5px; }
+#aliens {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 20px;
+}
+#alien-left { transform: scaleX(-1); }
+#beam {
+  width: 10px;
+  height: 5px;
+  background: yellow;
+  position: absolute;
+  top: 80px;
+  left: 50%;
+  margin-left: -5px;
+  animation: shoot 0.5s linear forwards;
+}
+.hidden { display: none; }
+@keyframes shoot {
+  from { transform: translateX(0); }
+  to { transform: translateX(300px); }
+}
+#victory {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.8);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+.alien.victory {
+  width: 80px;
+  height: 80px;
+  background: gold;
+}


### PR DESCRIPTION
## Summary
- add a small set of common phrases in `phrases.csv`
- create `index.html` with page layout and hooks for the game
- add basic aliens and animations in `style.css`
- implement game logic and scoring in `script.js`
- expand README with running instructions

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684217e5b75c8329be9028eba2e07e08